### PR TITLE
Match newbies randomly

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -40,6 +40,7 @@ FORCE_STEAM_LINK = os.getenv('FORCE_STEAM_LINK', 'false').lower() == 'true'
 
 NEWBIE_BASE_MEAN = int(os.getenv('NEWBIE_BASE_MEAN', 500))
 NEWBIE_MIN_GAMES = int(os.getenv('NEWBIE_MIN_GAMES', 10))
+TOP_PLAYER_MIN_RATING = int(os.getenv('TOP_PLAYER_MIN_RATING', 2000))
 
 TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID", "")
 TWILIO_TOKEN = os.getenv("TWILIO_TOKEN", "")

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -63,10 +63,10 @@ class StableMarriage(object):
 
     def _forcefully_match_unmatched_newbies(self):
         unmatched_newbies = [
-            search in self.searches 
+            search for search in self.searches 
             if search.is_single_ladder_newbie()
             and not search in self.matches
-        ]
+        ] 
 
         while 2 <= len(unmatched_newbies):
             newbie1 = unmatched_newbies.pop()

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -75,13 +75,14 @@ class StableMarriage(object):
 
         if len(unmatched_newbies) == 1:
             newbie = unmatched_newbies[0]
+            default_if_no_available_opponent = None
             opponent = next(
                 (search for search in  self.searches
                 if search != newbie
                 and not search in self.matches),
-                None
+                default_if_no_available_opponent
             )
-            if opponent is not None:
+            if opponent is not default_if_no_available_opponent:
                 self._match(newbie, opponent)
 
 

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -57,7 +57,33 @@ class StableMarriage(object):
 
                 self._propose(search, preferred)
 
+        self._forcefully_match_unmatched_newbies()
+
         return self._remove_duplicates()
+
+    def _forcefully_match_unmatched_newbies(self):
+        unmatched_newbies = [
+            search in self.searches 
+            if search.is_single_ladder_newbie()
+            and not search in self.matches
+        ]
+
+        while 2 <= len(unmatched_newbies):
+            newbie1 = unmatched_newbies.pop()
+            newbie2 = unmatched_newbies.pop()
+            self._match(newbie1, newbie2)
+
+        if len(unmatched_newbies) == 1:
+            newbie = unmatched_newbies[0]
+            opponent = next(
+                (search for search in  self.searches
+                if search != newbie
+                and not search in self.matches),
+                None
+            )
+            if opponent is not None:
+                self._match(newbie, opponent)
+
 
     def _remove_duplicates(self) -> List[Match]:
         matches_set: Set[Match] = set()

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -68,7 +68,7 @@ class StableMarriage(object):
             and not search in self.matches
         ] 
 
-        while 2 <= len(unmatched_newbies):
+        while len(unmatched_newbies) >= 2:
             newbie1 = unmatched_newbies.pop()
             newbie2 = unmatched_newbies.pop()
             self._match(newbie1, newbie2)
@@ -76,7 +76,7 @@ class StableMarriage(object):
         if len(unmatched_newbies) == 1:
             newbie = unmatched_newbies[0]
             opponent = next(
-                (search for search in  self.searches
+                (search for search in self.searches
                 if search != newbie
                 and not search in self.matches),
                 None

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -79,7 +79,8 @@ class StableMarriage(object):
             opponent = next(
                 (search for search in  self.searches
                 if search != newbie
-                and not search in self.matches),
+                and not search in self.matches
+                and search.is_single_party()),
                 default_if_no_available_opponent
             )
             if opponent is not default_if_no_available_opponent:

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -75,12 +75,16 @@ class StableMarriage(object):
 
         if len(unmatched_newbies) == 1:
             newbie = unmatched_newbies[0]
+
             default_if_no_available_opponent = None
+
             opponent = next(
                 (search for search in self.searches
                 if search != newbie
                 and not search in self.matches
-                and search.is_single_party()),
+                and search.is_single_party()
+                and search.has_no_top_player()
+                ),
                 default_if_no_available_opponent
             )
             if opponent is not default_if_no_available_opponent:

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -8,7 +8,7 @@ from typing import Deque, Dict
 import server
 
 from ..decorators import with_logger
-from .algorithm import stable_marriage
+from .algorithm import make_matches
 from .pop_timer import PopTimer
 from .search import Match, Search
 
@@ -96,7 +96,7 @@ class MatchmakerQueue:
         # Call self.match on all matches and filter out the ones that were canceled
         new_matches = filter(
             lambda m: self.match(m[0], m[1]),
-            stable_marriage(self.queue.values())
+            make_matches(self.queue.values())
         )
         self._matches.extend(new_matches)
 

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -219,5 +219,4 @@ class Search:
     def __str__(self):
         return "Search({}, {}, {})".format(self.players, self.match_threshold, self.search_expansion)
 
-
 Match = Tuple[Search, Search]

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -66,6 +66,11 @@ class Search:
             and self.is_ladder_search()
         )
 
+    def has_no_top_player(self) -> bool:
+        max_rating = max(map(lambda rating_tuple: rating_tuple[0], self.ratings))
+        return max_rating < config.TOP_PLAYER_MIN_RATING
+
+
     @property
     def ratings(self):
         ratings = []

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -51,14 +51,14 @@ class Search:
 
     @staticmethod
     def is_ladder_newbie(player: Player) -> bool:
-        return (
-            player.ladder_games <= config.NEWBIE_MIN_GAMES
-            and
-            self.rating_prop == 'ladder_rating'
-        )
+        return player.ladder_games <= config.NEWBIE_MIN_GAMES
 
-    def is_single_newbie(self) -> bool:
-        return len(self.players) == 1 and self.is_ladder_newbie(self.players[0])
+    def is_single_ladder_newbie(self) -> bool:
+        return (
+            len(self.players) == 1 
+            and self.is_ladder_newbie(self.players[0])
+            and self.rating_prop == 'ladder_rating'
+        )
 
     @property
     def ratings(self):

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -50,14 +50,20 @@ class Search:
         return adjusted_mean, dev
 
     @staticmethod
-    def is_ladder_newbie(player: Player) -> bool:
+    def _is_ladder_newbie(player: Player) -> bool:
         return player.ladder_games <= config.NEWBIE_MIN_GAMES
+
+    def is_ladder_search(self) -> bool:
+        return self.rating_prop == 'ladder_rating'
+
+    def is_single_party(self) -> bool:
+        return len(self.players) == 1
 
     def is_single_ladder_newbie(self) -> bool:
         return (
-            len(self.players) == 1 
-            and self.is_ladder_newbie(self.players[0])
-            and self.rating_prop == 'ladder_rating'
+            self.is_single_party()
+            and self._is_ladder_newbie(self.players[0])
+            and self.is_ladder_search()
         )
 
     @property
@@ -65,7 +71,7 @@ class Search:
         ratings = []
         for player, rating in zip(self.players, self.raw_ratings):
             # New players (less than config.NEWBIE_MIN_GAMES games) match against less skilled opponents
-            if self.is_ladder_newbie(player):
+            if self._is_ladder_newbie(player):
                 rating = self.adjusted_rating(player)
             ratings.append(rating)
         return ratings
@@ -179,7 +185,7 @@ class Search:
         self._logger.info("Matched %s with %s", self.players, other.players)
 
         for player, raw_rating in zip(self.players, self.raw_ratings):
-            if self.is_ladder_newbie(player):
+            if self._is_ladder_newbie(player):
                 mean, dev = raw_rating
                 adjusted_mean = self.adjusted_rating(player)
                 self._logger.info('Adjusted mean rating for {player} with {ladder_games} games from {mean} to {adjusted_mean}'.format(

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -49,12 +49,23 @@ class Search:
                          + player.ladder_games * mean) / config.NEWBIE_MIN_GAMES
         return adjusted_mean, dev
 
+    @staticmethod
+    def is_ladder_newbie(player: Player) -> bool:
+        return (
+            player.ladder_games <= config.NEWBIE_MIN_GAMES
+            and
+            self.rating_prop == 'ladder_rating'
+        )
+
+    def is_single_newbie(self) -> bool:
+        return len(self.players) == 1 and self.is_ladder_newbie(self.players[0])
+
     @property
     def ratings(self):
         ratings = []
         for player, rating in zip(self.players, self.raw_ratings):
             # New players (less than config.NEWBIE_MIN_GAMES games) match against less skilled opponents
-            if player.ladder_games <= config.NEWBIE_MIN_GAMES and self.rating_prop == 'ladder_rating':
+            if self.is_ladder_newbie(player):
                 rating = self.adjusted_rating(player)
             ratings.append(rating)
         return ratings
@@ -168,13 +179,12 @@ class Search:
         self._logger.info("Matched %s with %s", self.players, other.players)
 
         for player, raw_rating in zip(self.players, self.raw_ratings):
-            ladder_games = player.ladder_games
-            if ladder_games <= config.NEWBIE_MIN_GAMES:
+            if self.is_ladder_newbie(player):
                 mean, dev = raw_rating
                 adjusted_mean = self.adjusted_rating(player)
                 self._logger.info('Adjusted mean rating for {player} with {ladder_games} games from {mean} to {adjusted_mean}'.format(
                     player=player,
-                    ladder_games=ladder_games,
+                    ladder_games=player.ladder_games,
                     mean=mean,
                     adjusted_mean=adjusted_mean
                 ))

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -36,7 +36,7 @@ def matchmaker_players_all_match():
 
 def test_is_ladder_newbie(matchmaker_players):
     pro, _, _, _, _, newbie = matchmaker_players
-    assert Search.is_ladder_newbie(pro) == False
+    assert Search.is_ladder_newbie(pro) is False
     assert Search.is_ladder_newbie(newbie)
 
 

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -49,11 +49,11 @@ def test_is_single_newbie(matchmaker_players):
     two_pros = Search([pro, pro])
     two_mixed = Search([newbie, pro])
 
-    assert single_newbie.is_single_newbie()
-    assert single_pro.is_single_newbie() == False
-    assert two_newbies.is_single_newbie() == False
-    assert two_pros.is_single_newbie() == False
-    assert two_mixed.is_single_newbie() == False
+    assert single_newbie.is_single_ladder_newbie()
+    assert single_pro.is_single_ladder_newbie() == False
+    assert two_newbies.is_single_ladder_newbie() == False
+    assert two_pros.is_single_ladder_newbie() == False
+    assert two_mixed.is_single_ladder_newbie() == False
 
 
 def test_newbies_have_adjusted_rating(matchmaker_players):

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -34,10 +34,32 @@ def matchmaker_players_all_match():
            Player('Rhiza', player_id=5, ladder_rating=(1500, 50), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
 
 
-def test_newbie_min_games(matchmaker_players):
-    p1, _, _, _, _, p6 = matchmaker_players
-    s1, s6 = Search([p1]), Search([p6])
-    assert s1.ratings[0] == p1.ladder_rating and s6.ratings[0] != p6.ladder_rating
+def test_is_ladder_newbie(matchmaker_players):
+    pro, _, _, _, _, newbie = matchmaker_players
+    assert Search.is_ladder_newbie(pro) == False
+    assert Search.is_ladder_newbie(newbie)
+
+
+def test_is_single_newbie(matchmaker_players):
+    pro, _, _, _, _, newbie = matchmaker_players
+
+    single_newbie = Search([newbie])
+    single_pro = Search([pro])
+    two_newbies = Search([newbie, newbie])
+    two_pros = Search([pro, pro])
+    two_mixed = Search([newbie, pro])
+
+    assert single_newbie.is_single_newbie()
+    assert single_pro.is_single_newbie() == False
+    assert two_newbies.is_single_newbie() == False
+    assert two_pros.is_single_newbie() == False
+    assert two_mixed.is_single_newbie() == False
+
+
+def test_newbies_have_adjusted_rating(matchmaker_players):
+    pro, _, _, _, _, newbie = matchmaker_players
+    s1, s6 = Search([pro]), Search([newbie])
+    assert s1.ratings[0] == pro.ladder_rating and s6.ratings[0] != newbie.ladder_rating
 
 
 def test_search_threshold(matchmaker_players):

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -36,8 +36,8 @@ def matchmaker_players_all_match():
 
 def test_is_ladder_newbie(matchmaker_players):
     pro, _, _, _, _, newbie = matchmaker_players
-    assert Search.is_ladder_newbie(pro) is False
-    assert Search.is_ladder_newbie(newbie)
+    assert Search._is_ladder_newbie(pro) is False
+    assert Search._is_ladder_newbie(newbie)
 
 
 def test_is_single_newbie(matchmaker_players):

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -138,7 +138,7 @@ def test_newbies_are_forcefully_matched_with_newbies():
 
 
 def test_unmatched_newbies_forcefully_match_pros():
-    newbie = Search([p(0, 500, ladder_games=0)])
+    newbie = Search([p(1500, 500, ladder_games=0)])
     pro = Search([p(2500, 10, ladder_games=100)])
 
     searches = [newbie, pro]

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -148,9 +148,9 @@ def test_unmatched_newbies_forcefully_match_pros()
 
 
 def test_odd_number_of_unmatched_newbies()
-    newbie1 = Search([p(0, 500, ladder_games=9)])
-    newbie2 = Search([p(2500, 500, ladder_games=9)])
-    newbie3 = Search([p(5500, 500, ladder_games=9)])
+    newbie1 = Search([p(-250, 500, ladder_games=9)])
+    newbie2 = Search([p(750, 500, ladder_games=9)])
+    newbie3 = Search([p(1500, 500, ladder_games=9)])
     pro = Search([p(2500, 10, ladder_games=100)])
 
     searches = [newbie1, pro, newbie2]

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -126,7 +126,7 @@ def test_stable_marriage_unmatch():
     assert (s2, s3) in matches  # quality: 0.96623
 
 
-def test_newbies_are_forcefully_matched_with_newbies()
+def test_newbies_are_forcefully_matched_with_newbies():
     newbie1 = Search([p(0, 500, ladder_games=9)])
     newbie2 = Search([p(2500, 500, ladder_games=9)])
     pro = Search([p(2500, 10, ladder_games=100)])
@@ -137,23 +137,23 @@ def test_newbies_are_forcefully_matched_with_newbies()
     assert (newbie1, newbie2) in matches or (newbie2, newbie1) in matches
 
 
-def test_unmatched_newbies_forcefully_match_pros()
+def test_unmatched_newbies_forcefully_match_pros():
     newbie = Search([p(0, 500, ladder_games=0)])
     pro = Search([p(2500, 10, ladder_games=100)])
 
-    searches = [newbie1, pro, newbie2]
+    searches = [newbie, pro]
     matches = algorithm.stable_marriage(searches)
 
     assert (newbie, pro) in matches or (pro, newbie) in matches
 
 
-def test_odd_number_of_unmatched_newbies()
+def test_odd_number_of_unmatched_newbies():
     newbie1 = Search([p(0, 500, ladder_games=9)])
     newbie2 = Search([p(2500, 500, ladder_games=9)])
     newbie3 = Search([p(5500, 500, ladder_games=9)])
     pro = Search([p(2500, 10, ladder_games=100)])
 
-    searches = [newbie1, pro, newbie2]
+    searches = [newbie1, pro, newbie2, newbie3]
     matches = algorithm.stable_marriage(searches)
 
     assert len(matches) == 2

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -170,7 +170,7 @@ def team_unmatched_newbies_do_not_forcefully_match_pros():
     assert len(matches) == 0
 
 
-def test_odd_number_of_unmatched_newbies()
+def test_odd_number_of_unmatched_newbies():
     newbie1 = Search([p(-250, 500, ladder_games=9)])
     newbie2 = Search([p(750, 500, ladder_games=9)])
     newbie3 = Search([p(1500, 500, ladder_games=9)])

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -40,6 +40,24 @@ def test_rank_all_will_not_include_matches_below_threshold_quality():
     }
 
 
+def test_stable_marriage_produces_symmetric_matchings():
+    s1 = Search([p(2300, 64, name='p1')])
+    s2 = Search([p(1200, 72, name='p2')])
+    s3 = Search([p(1300, 175, name='p3')])
+    s4 = Search([p(2350, 125, name='p4')])
+    s5 = Search([p(1200, 175, name='p5')])
+    s6 = Search([p(1250, 175, name='p6')])
+
+    searches = [s1, s2, s3, s4, s5, s6]
+
+    matches = algorithm.StableMarriage(searches).find()
+
+    for search in matches:
+        opponent = matches[search]
+        assert matches[opponent] == search
+
+
+
 def test_stable_marriage():
     s1 = Search([p(2300, 64, name='p1')])
     s2 = Search([p(1200, 72, name='p2')])
@@ -50,11 +68,12 @@ def test_stable_marriage():
 
     searches = [s1, s2, s3, s4, s5, s6]
 
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.StableMarriage(searches).find()
 
-    assert (s1, s4) in matches
-    assert (s2, s5) in matches
-    assert (s3, s6) in matches
+    assert matches[s1] == s4
+    assert matches[s2] == s5
+    assert matches[s3] == s6
+
 
 def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_different_mean():
     new1 = Search([p(1500, 500, name='new1', ladder_games=1)])
@@ -64,10 +83,10 @@ def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_differ
 
     searches = [new1, new2, old1, old2]
 
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.StableMarriage(searches).find()
 
-    assert (new1, new2) in matches
-    assert (old1, old2) in matches
+    assert matches[new1] == new2
+    assert matches[old1] == old2
 
 
 def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_same_mean():
@@ -80,10 +99,10 @@ def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_same_m
 
     searches = [new1, new2, old1, old2]
 
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.StableMarriage(searches).find()
 
-    assert (new1, new2) in matches or (new2, new1) in matches
-    assert (old1, old2) in matches or (old2, old1) in matches
+    assert matches[new1] == new2
+    assert matches[old1] == old2
 
 
 def test_stable_marriage_better_than_greedy():
@@ -96,18 +115,18 @@ def test_stable_marriage_better_than_greedy():
 
     searches = [s1, s2, s3, s4, s5, s6]
 
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.StableMarriage(searches).find()
 
     # Note that the most balanced configuration would be
-    # assert (s1, s6) in matches  # quality: 0.93
-    # assert (s2, s3) in matches  # quality: 0.93
-    # assert (s4, s5) in matches  # quality: 0.93
+    # (s1, s6)  quality: 0.93
+    # (s2, s3)  quality: 0.93
+    # (s4, s5)  quality: 0.93
 
     # However, because s1 is first in the list and gets top choice, we end with
     # the following stable configuration
-    assert (s1, s5) in matches  # quality: 0.97
-    assert (s2, s3) in matches  # quality: 0.93
-    assert (s6, s4) in matches  # quality: 0.82
+    assert matches[s1] == s5 # quality: 0.97
+    assert matches[s2] == s3 # quality: 0.93
+    assert matches[s4] == s6 # quality: 0.82
 
 
 def test_stable_marriage_unmatch():
@@ -118,12 +137,26 @@ def test_stable_marriage_unmatch():
 
     searches = [s1, s2, s3, s4]
 
-    matches = algorithm.stable_marriage(searches)
-    for m1, m2 in matches:
-        print(m1, m2, m1.quality_with(m2))
+    matches = algorithm.StableMarriage(searches).find()
 
-    assert (s1, s4) in matches  # quality: 0.96622
-    assert (s2, s3) in matches  # quality: 0.96623
+    assert matches[s1] == s4 # quality: 0.96622
+    assert matches[s2] == s3  # quality: 0.96623
+
+
+def test_random_newbie_matching_is_symmetric():
+    s1 = Search([p(1000, 500, name='p1', ladder_games=5)])
+    s2 = Search([p(1200, 500, name='p2', ladder_games=5)])
+    s3 = Search([p(900, 500, name='p3', ladder_games=5)])
+    s4 = Search([p(1500, 500, name='p4', ladder_games=5)])
+    s5 = Search([p(1700, 500, name='p5', ladder_games=5)])
+    s6 = Search([p(600, 500, name='p6', ladder_games=5)])
+
+    searches = [s1, s2, s3, s4, s5, s6]
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
+
+    for search in matches:
+        opponent = matches[search]
+        assert matches[opponent] == search
 
 
 def test_newbies_are_forcefully_matched_with_newbies():
@@ -132,9 +165,10 @@ def test_newbies_are_forcefully_matched_with_newbies():
     pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie1, pro, newbie2]
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
 
-    assert (newbie1, newbie2) in matches or (newbie2, newbie1) in matches
+    assert matches[newbie1] == newbie2
+    assert matches[newbie2] == newbie1
 
 
 def test_unmatched_newbies_forcefully_match_pros():
@@ -142,17 +176,17 @@ def test_unmatched_newbies_forcefully_match_pros():
     pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie, pro]
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
 
-    assert len(matches) == 1
+    assert len(matches) == 2
 
 
 def test_unmatched_newbies_do_notforcefully_match_top_players():
     newbie = Search([p(1500, 500, ladder_games=0)])
-    pro = Search([p(2500, 10, ladder_games=100)])
+    top_player = Search([p(2500, 10, ladder_games=100)])
 
-    searches = [newbie, pro]
-    matches = algorithm.stable_marriage(searches)
+    searches = [newbie, top_player]
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
 
     assert len(matches) == 0
 
@@ -162,7 +196,7 @@ def test_unmatched_newbies_do_not_forcefully_match_teams():
     team = Search([p(1500, 100), p(1500, 100)])
 
     searches = [newbie, team]
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
 
     assert len(matches) == 0
 
@@ -175,7 +209,7 @@ def unmatched_newbie_teams_do_not_forcefully_match_pros():
     pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie_team, pro]
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
 
     assert len(matches) == 0
 
@@ -187,6 +221,35 @@ def test_odd_number_of_unmatched_newbies():
     pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie1, pro, newbie2, newbie3]
-    matches = algorithm.stable_marriage(searches)
+    matches = algorithm.RandomlyMatchNewbies(searches).find()
 
-    assert len(matches) == 2
+    assert len(matches) == 4
+
+def test_matchmaker():
+    newbie_that_matches1 = Search([p(1450, 500, ladder_games=1)])
+    newbie_that_matches2 = Search([p(1550, 500, ladder_games=1)])
+    newbie_force_matched = Search([p(200, 400, ladder_games=9)])
+
+    pro_that_matches1 = Search([p(1800, 60, ladder_games=101)])
+    pro_that_matches2 = Search([p(1750, 50, ladder_games=100)])
+    pro_alone = Search([p(1600, 50, ladder_games=100)])
+
+    top_player = Search([p(2100, 50, ladder_games=200)])
+
+    searches = [
+        newbie_that_matches1,
+        newbie_that_matches2,
+        newbie_force_matched,
+        pro_that_matches1,
+        pro_that_matches2,
+        pro_alone,
+        top_player
+    ]
+    match_pairs = algorithm.make_matches(searches)
+    match_sets = [set(pair) for pair in match_pairs]
+
+    assert {newbie_that_matches1, newbie_that_matches2} in match_sets
+    assert {pro_that_matches1, pro_that_matches2} in match_sets
+    assert {newbie_force_matched, pro_alone} in match_sets
+    for match_pair in match_pairs:
+        assert top_player not in match_pair

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -128,8 +128,8 @@ def test_stable_marriage_unmatch():
 
 def test_newbies_are_forcefully_matched_with_newbies():
     newbie1 = Search([p(0, 500, ladder_games=9)])
-    newbie2 = Search([p(2500, 500, ladder_games=9)])
-    pro = Search([p(2500, 10, ladder_games=100)])
+    newbie2 = Search([p(1500, 500, ladder_games=9)])
+    pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie1, pro, newbie2]
     matches = algorithm.stable_marriage(searches)
@@ -139,12 +139,22 @@ def test_newbies_are_forcefully_matched_with_newbies():
 
 def test_unmatched_newbies_forcefully_match_pros():
     newbie = Search([p(1500, 500, ladder_games=0)])
+    pro = Search([p(1800, 10, ladder_games=100)])
+
+    searches = [newbie, pro]
+    matches = algorithm.stable_marriage(searches)
+
+    assert len(matches) == 1
+
+
+def test_unmatched_newbies_do_notforcefully_match_top_players():
+    newbie = Search([p(1500, 500, ladder_games=0)])
     pro = Search([p(2500, 10, ladder_games=100)])
 
     searches = [newbie, pro]
     matches = algorithm.stable_marriage(searches)
 
-    assert (newbie, pro) in matches or (pro, newbie) in matches
+    assert len(matches) == 0
 
 
 def test_unmatched_newbies_do_not_forcefully_match_teams():
@@ -157,12 +167,12 @@ def test_unmatched_newbies_do_not_forcefully_match_teams():
     assert len(matches) == 0
 
 
-def team_unmatched_newbies_do_not_forcefully_match_pros():
+def unmatched_newbie_teams_do_not_forcefully_match_pros():
     newbie_team = Search([
         p(1500, 500, ladder_games=0),
         p(1500, 500, ladder_games=0)
     ])
-    pro = Search([p(2500, 10, ladder_games=100)])
+    pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie_team, pro]
     matches = algorithm.stable_marriage(searches)
@@ -174,7 +184,7 @@ def test_odd_number_of_unmatched_newbies():
     newbie1 = Search([p(-250, 500, ladder_games=9)])
     newbie2 = Search([p(750, 500, ladder_games=9)])
     newbie3 = Search([p(1500, 500, ladder_games=9)])
-    pro = Search([p(2500, 10, ladder_games=100)])
+    pro = Search([p(1800, 10, ladder_games=100)])
 
     searches = [newbie1, pro, newbie2, newbie3]
     matches = algorithm.stable_marriage(searches)

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -147,6 +147,29 @@ def test_unmatched_newbies_forcefully_match_pros()
     assert (newbie, pro) in matches or (pro, newbie) in matches
 
 
+def test_unmatched_newbies_do_not_forcefully_match_teams():
+    newbie = Search([p(1500, 500, ladder_games=0)])
+    team = Search([p(1500, 100), p(1500, 100)])
+
+    searches = [newbie, team]
+    matches = algorithm.stable_marriage(searches)
+
+    assert len(matches) == 0
+
+
+def team_unmatched_newbies_do_not_forcefully_match_pros():
+    newbie_team = Search([
+        p(1500, 500, ladder_games=0),
+        p(1500, 500, ladder_games=0)
+    ])
+    pro = Search([p(2500, 10, ladder_games=100)])
+
+    searches = [newbie_team, pro]
+    matches = algorithm.stable_marriage(searches)
+
+    assert len(matches) == 0
+
+
 def test_odd_number_of_unmatched_newbies()
     newbie1 = Search([p(-250, 500, ladder_games=9)])
     newbie2 = Search([p(750, 500, ladder_games=9)])

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -124,3 +124,36 @@ def test_stable_marriage_unmatch():
 
     assert (s1, s4) in matches  # quality: 0.96622
     assert (s2, s3) in matches  # quality: 0.96623
+
+
+def test_newbies_are_forcefully_matched_with_newbies()
+    newbie1 = Search([p(0, 500, ladder_games=9)])
+    newbie2 = Search([p(2500, 500, ladder_games=9)])
+    pro = Search([p(2500, 10, ladder_games=100)])
+
+    searches = [newbie1, pro, newbie2]
+    matches = algorithm.stable_marriage(searches)
+
+    assert (newbie1, newbie2) in matches or (newbie2, newbie1) in matches
+
+
+def test_unmatched_newbies_forcefully_match_pros()
+    newbie = Search([p(0, 500, ladder_games=0)])
+    pro = Search([p(2500, 10, ladder_games=100)])
+
+    searches = [newbie1, pro, newbie2]
+    matches = algorithm.stable_marriage(searches)
+
+    assert (newbie, pro) in matches or (pro, newbie) in matches
+
+
+def test_odd_number_of_unmatched_newbies()
+    newbie1 = Search([p(0, 500, ladder_games=9)])
+    newbie2 = Search([p(2500, 500, ladder_games=9)])
+    newbie3 = Search([p(5500, 500, ladder_games=9)])
+    pro = Search([p(2500, 10, ladder_games=100)])
+
+    searches = [newbie1, pro, newbie2]
+    matches = algorithm.stable_marriage(searches)
+
+    assert len(matches) == 2


### PR DESCRIPTION
As suggested: match newbie players randomly if the stable marriage didn't match them.

Prefers to match two unmatched newbies with each other before matching with a "normal" player.